### PR TITLE
add groupTimeout list for different times for different groups, and MMM-Config schema

### DIFF
--- a/MMM-Config.schema.json
+++ b/MMM-Config.schema.json
@@ -1,0 +1,169 @@
+{
+  "schema": {
+    "MMM-ModulesGroupsRotation": {
+      "type": "object",
+      "title": "properties for MMM-ModulesGroupsRotation",
+      "properties": {
+        "module": {
+          "type": "string",
+          "title": "module",
+          "default": "MMM-ModulesGroupsRotation",
+          "readonly": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "title": "disabled",
+          "default": false
+        },
+        "position": {
+          "type": "string",
+          "title": "module position",
+          "readonly": "true"
+        },
+        "classes": {
+          "type": "string",
+          "title": "classes",
+          "default": ""
+        },
+        "order": {
+          "type": "string",
+          "title": "order",
+          "default": "*"
+        },
+        "inconfig": {
+          "type": "string",
+          "title": "inconfig",
+          "default": "0"
+        },
+        "index": {
+          "type": "integer"
+        },
+        "config": {
+          "type": "object",
+          "title": "config",
+          "properties": {
+            "modulesGroups": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "rotationTime": {
+              "type": "integer"
+            },
+            "animationDelay": {
+              "type": "integer"
+            },
+            "groupDelay": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "groupNumber": {
+                    "type": "integer"
+                  },
+                  "timeout": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "form": [
+    {
+      "key": "MMM-ModulesGroupsRotation.disabled",
+      "htmlClass": "disabled_checkbox",
+      "description": "when checked the module will not be used by MagicMirror<br> but will remain in config.js if already present"
+    },
+    {
+      "key": "MMM-ModulesGroupsRotation.position",
+      "description": "use Module Positions section below to set or change"
+    },
+    {
+      "key": "MMM-ModulesGroupsRotation.classes",
+      "description": "css classes to use for this module, beyond what MM provides"
+    },
+    {
+      "key": "MMM-ModulesGroupsRotation.order",
+      "type": "hidden"
+    },
+    {
+      "key": "MMM-ModulesGroupsRotation.inconfig",
+      "type": "hidden"
+    },
+    {
+      "key": "MMM-ModulesGroupsRotation.index",
+      "type": "hidden"
+    },
+    {
+      "type": "fieldset",
+      "title": "config",
+      "items": [
+        {
+          "type": "array",
+          "title": "modulesGroups",
+          "items": {
+            "type": "array",
+            "title": "group module name or classname list {{idx}}",
+            "items": [
+              {
+                "title": "module or class name {{idx}}",
+                "key": "MMM-ModulesGroupsRotation.config.modulesGroups[][]"
+              }
+            ]
+          }
+        },
+        {
+          "title": "rotationTime",
+          "key": "MMM-ModulesGroupsRotation.config.rotationTime"
+        },
+        {
+          "title": "animationDelay",
+          "key": "MMM-ModulesGroupsRotation.config.animationDelay"
+        },
+        {
+          "type": "array",
+          "title": "group module display time list",
+          "deleteCurrent": false,
+          "items": {
+            "type": "fieldset",
+            "title": "groupDelay",
+            "items": [
+              {
+                "title": "groupNumber",
+                "key": "MMM-ModulesGroupsRotation.config.groupDelay[].groupNumber"
+              },
+              {
+                "title": "timeout",
+                "key": "MMM-ModulesGroupsRotation.config.groupDelay[].timeout"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "value": {
+    "disabled": true,
+    "module": "MMM-ModulesGroupsRotation",
+    "position": "none",
+    "order": "*",
+    "inconfig": "0",
+    "config": {
+      "modulesGroups": [
+        [
+        ]
+      ],
+      "rotationTime": 3000,
+      "animationDelay": 1000,
+      "groupDelay": []
+    }
+  }
+}

--- a/MMM-ModulesGroupsRotation.js
+++ b/MMM-ModulesGroupsRotation.js
@@ -1,31 +1,51 @@
 Module.register("MMM-ModulesGroupsRotation", {
     // Module config defaults.
     defaults: {
-        modulesGroups: [],
+        modulesGroups: [["string"]],
         rotationTime: 3000,
-        animationDelay: 1000 // Animation delay in milliseconds
+        animationDelay: 1000,// Animation delay in milliseconds
+        groupDelay:[{groupNumber:1,timeout:10000}]
     },
-
+    // used to calc delay for individual groups
+    timeout_delay:0,
     // Define start sequence.
     start() {
         Log.log(`Page start timer for rotating modules`);
-        this.curGroup = 0;
-        this.timer = setInterval(() => {
-            this.rotateModules();
-        }, this.config.rotationTime);
+        this.curGroup = -1;
+        // if no separate group delays
+        if(this.groupDelay.length==0){
+            // do it like before
+            this.timer = setInterval(() => {
+                this.rotateModules();
+            }, this.config.rotationTime);
+        }
     },
 
     rotateModules: function () {
+        // Hide all modules first with a transition
+        this.hideAllModules();
+
         this.curGroup = (this.curGroup + 1) % this.config.modulesGroups.length;
         Log.log(`this.curGroup:`, this.curGroup);
 
-        // Hide all modules first with a transition
-       this.hideAllModules();
-
+        this.timeout_delay=this.config.rotationTime
+        for(group of groupDelay){
+            if((group.groupNumber>0) && ((group.groupNumber-1) == this.curGroup)){
+                this.timeout_delay=group.timeout
+                break;
+            }
+        }
+        // fire quickly on startup
+        let animationDelay= this.curGroup == 0?1:this.config.animationDelay
         // Show modules in the current group after a short delay to allow hide transition to complete
         setTimeout(() => {
             this.showCurrentGroup()
-        }, this.config.animationDelay); 
+            if(this.groupDelay.length){
+                this.timer = setTimeout(() => {
+                    this.rotateModules();
+                }, this.timeout_delay);
+            }
+        }, animationDelay);
     },
 
     fadeOut(module) {
@@ -61,8 +81,7 @@ Module.register("MMM-ModulesGroupsRotation", {
     // Override dom generator.
     getDom() {
         const wrapper = document.createElement("div");
-        this.hideAllModules();
-        this.showCurrentGroup();
+        this.rotateModules();
         return wrapper;
     },
 

--- a/MMM-ModulesGroupsRotation.js
+++ b/MMM-ModulesGroupsRotation.js
@@ -25,18 +25,25 @@ Module.register("MMM-ModulesGroupsRotation", {
         // Hide all modules first with a transition
         this.hideAllModules();
 
+        // fire quickly on startup
+        let animationDelay= this.curGroup == -1?1:this.config.animationDelay
+
         this.curGroup = (this.curGroup + 1) % this.config.modulesGroups.length;
         Log.log(`this.curGroup:`, this.curGroup);
 
+        // get the timeout for this group , start with the default
         this.timeout_delay=this.config.rotationTime
+        // loop thru the list of specified group timeouts
         for(group of groupDelay){
+            // if the group number is not negative, and it matches the currennt group
             if((group.groupNumber>0) && ((group.groupNumber-1) == this.curGroup)){
+                // get its delay time
                 this.timeout_delay=group.timeout
+                // break loop, only one for this group
                 break;
             }
         }
-        // fire quickly on startup
-        let animationDelay= this.curGroup == 0?1:this.config.animationDelay
+
         // Show modules in the current group after a short delay to allow hide transition to complete
         setTimeout(() => {
             this.showCurrentGroup()

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ The following properties can be configured:
 
 | Option           | Description                                                                          | Default |
 |------------------|--------------------------------------------------------------------------------------|---------|
-| `modulesGroups`  | An array of arrays containing the names of modules to group and rotate through.      | `[]`    |
+| `modulesGroups`  | An array of arrays containing the names of modules to group and rotate through.      | `[[]]`  |
 | `rotationTime`   | Time in milliseconds between module rotations.                                       | `3000`  |
 | `animationDelay` | Time in milliseconds for the fade in/out animation when toggling module visibility.  | `1000`  |
+| `groupDelay`     | array of structures,  enable different timeouts for different groups  |  `[]`  |
+|| groupNumber starts at 1 for the first group, timeout is in milliseconds ||    
+|| { groupNumber: n, timeout: mmmmm }||
+|| { groupNumber:5, timeout:5\*60\*1000}  // 5th group , timeout is 5 minutes ||
+          
 
 Example configuration:
 


### PR DESCRIPTION
like Carousel, and Pages added support for different delays on different groups.. 
restructed a tiny bit to call this.rotateModules(); from getDom() instead of doing separately

use setTimeout per group, instead of setInterval once. 
set new timeout at end of  the timeout in rotateModules()
updated the readme too